### PR TITLE
update to jetpack 3.2.1

### DIFF
--- a/Dockerfile.cudabase
+++ b/Dockerfile.cudabase
@@ -6,7 +6,7 @@ MAINTAINER nuculur@gmail.com
 # This is the base container for the Jetson TX2 board with drivers (with cuda)
 
 # base URL for NVIDIA libs
-ARG URL=http://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.2/pwv346/JetPackL4T_32_b157
+ARG URL=https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.2.1/m8u2ki/JetPackL4T_321_b23
 
 # Update packages, install some useful packages
 RUN apt-get update && apt-get install -y apt-utils bzip2 curl sudo unp && apt-get clean && rm -rf /var/cache/apt
@@ -19,8 +19,8 @@ RUN /tmp/Linux_for_Tegra/apply_binaries.sh -r / && rm -fr /tmp/*
 
 ## Pull the rest of the jetpack libs for cuda/cudnn and install
 RUN curl $URL/cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb -so cuda-repo-l4t_arm64.deb
-RUN curl $URL/libcudnn7_7.0.5.13-1+cuda9.0_arm64.deb -so /tmp/libcudnn_arm64.deb
-RUN curl $URL/libcudnn7-dev_7.0.5.13-1+cuda9.0_arm64.deb -so /tmp/libcudnn-dev_arm64.deb
+RUN curl $URL/libcudnn7_7.0.5.15-1+cuda9.0_arm64.deb -so /tmp/libcudnn_arm64.deb
+RUN curl $URL/libcudnn7-dev_7.0.5.15-1+cuda9.0_arm64.deb -so /tmp/libcudnn-dev_arm64.deb
 
 ## Install libs: L4T, CUDA, cuDNN
 RUN dpkg -i /tmp/cuda-repo-l4t_arm64.deb


### PR DESCRIPTION
jetpack files 3.2 aren’t available anymore, build failed.
-> updated the urls